### PR TITLE
First buggy version of attach points for pl0012.

### DIFF
--- a/BayoHook.vcxproj
+++ b/BayoHook.vcxproj
@@ -219,6 +219,7 @@
     <ClCompile Include="include\minhook\src\hook.c" />
     <ClCompile Include="include\minhook\src\trampoline.c" />
     <ClCompile Include="src\base.cpp" />
+    <ClCompile Include="src\bayonetta.cpp" />
     <ClCompile Include="src\gamehook.cpp" />
     <ClCompile Include="src\gameimgui.cpp" />
     <ClCompile Include="src\hooks\EndScene.cpp" />
@@ -256,6 +257,7 @@
     <ClInclude Include="include\minhook\src\hde\table64.h" />
     <ClInclude Include="include\minhook\src\trampoline.h" />
     <ClInclude Include="src\base.h" />
+    <ClInclude Include="src\bayonetta.h" />
     <ClInclude Include="src\gamehook.hpp" />
     <ClInclude Include="src\LicenseStrings.hpp" />
     <ClInclude Include="src\pch.h" />

--- a/src/bayonetta.cpp
+++ b/src/bayonetta.cpp
@@ -25,7 +25,7 @@ bayoActor_loadATT(void* actor, void* attHandle) {
         numAttachPoints,
         GameHook::HeapSCNAddress);
     for (i = 0; i < numAttachPoints; i++) {
-        ((void (__thiscall*)(void*, int, int, int))GameHook::bayoActor_attachBoneAddress)(
+        ((void (__thiscall *)(void*, int, int, int))GameHook::bayoActor_attachBoneAddress)(
             actor,
             pAttachPoints[i].sourceBoneIndex,
             pAttachPoints[i].targetBoneIndex,
@@ -36,7 +36,7 @@ bayoActor_loadATT(void* actor, void* attHandle) {
 
 int __stdcall
 bayoPl0012_loadATT(void* actor) {
-    void * attHandle = ((void* (__cdecl*)(const char *))GameHook::bayo_getAssetHandleAddress)(
+    void * attHandle = ((void* (__cdecl *)(const char *))GameHook::bayo_getAssetHandleAddress)(
         "pl0012.dat\\pl0012.att");
     return bayoActor_loadATT(actor, attHandle);
 }

--- a/src/bayonetta.cpp
+++ b/src/bayonetta.cpp
@@ -1,0 +1,42 @@
+#include "bayonetta.h"
+#include "gamehook.hpp"
+
+struct bayoAttachPoint_t {
+    int sourceBoneIndex;
+    int targetBoneIndex;
+    int option;
+};
+
+static inline int
+bayoActor_loadATT(void* actor, void* attHandle) {
+    int numAttachPoints;
+    struct bayoAttachPoint_t* pAttachPoints;
+    int i;
+
+    if (!attHandle || *(int*)attHandle <= 0)
+        return 0;
+
+    numAttachPoints = *(int*)attHandle;
+    pAttachPoints = (struct bayoAttachPoint_t*)
+        ((int*)attHandle + 1);
+
+    ((int (__thiscall *)(void*, int, uintptr_t))GameHook::bayoActor_allocInitAttachPointsAddress)(
+        actor,
+        numAttachPoints,
+        GameHook::HeapSCNAddress);
+    for (i = 0; i < numAttachPoints; i++) {
+        ((void (__thiscall*)(void*, int, int, int))GameHook::bayoActor_attachBoneAddress)(
+            actor,
+            pAttachPoints[i].sourceBoneIndex,
+            pAttachPoints[i].targetBoneIndex,
+            pAttachPoints[i].option);
+    }
+    return 1;
+}
+
+int __stdcall
+bayoPl0012_loadATT(void* actor) {
+    void * attHandle = ((void* (__cdecl*)(const char *))GameHook::bayo_getAssetHandleAddress)(
+        "pl0012.dat\\pl0012.att");
+    return bayoActor_loadATT(actor, attHandle);
+}

--- a/src/bayonetta.h
+++ b/src/bayonetta.h
@@ -1,0 +1,4 @@
+#pragma once
+
+extern int __stdcall
+bayoPl0012_loadATT(void* actor);

--- a/src/gamehook.cpp
+++ b/src/gamehook.cpp
@@ -693,8 +693,8 @@ static __declspec(naked) void pl0012AttDetour(void) {
 		push edx
 		push esi
 		call bayoPl0012_loadATT
-		pop ecx
 		pop edx
+		pop ecx
 		test eax, eax
 		jnz success
 		jmp originalcode

--- a/src/gamehook.hpp
+++ b/src/gamehook.hpp
@@ -117,6 +117,10 @@ public:
 	static uintptr_t WeaponA2Address;
 	static uintptr_t WeaponB1Address;
 	static uintptr_t WeaponB2Address;
+	static uintptr_t HeapSCNAddress;
+	static uintptr_t bayo_getAssetHandleAddress;
+	static uintptr_t bayoActor_allocInitAttachPointsAddress;
+	static uintptr_t bayoActor_attachBoneAddress;
 
 	// imgui
 	static float windowHeightHack;

--- a/src/gameimgui.cpp
+++ b/src/gameimgui.cpp
@@ -38,6 +38,10 @@ uintptr_t GameHook::WeaponA1Address = 0x5AA741C;
 uintptr_t GameHook::WeaponA2Address = 0x5AA7420;
 uintptr_t GameHook::WeaponB1Address = 0x5AA742C;
 uintptr_t GameHook::WeaponB2Address = 0x5AA7430;
+uintptr_t GameHook::HeapSCNAddress = 0x5A57A78;
+uintptr_t GameHook::bayo_getAssetHandleAddress = 0xC5F5E0;
+uintptr_t GameHook::bayoActor_allocInitAttachPointsAddress = 0x451B20;
+uintptr_t GameHook::bayoActor_attachBoneAddress = 0x454C20;
 
 void help_marker(const char* desc) {
     ImGui::SameLine();


### PR DESCRIPTION
This is a WIP PR to add attach points to pl0012 (the sleeves of the default Bayonetta model.
As much as I'd love to be able to do it all by myself, I am pretty sure you have more experience than me here.

With my hook the game crashes when entering the gallery (it must load the model at this point).
Any Idea what I could have done wrong here?

In the meantime I am going to try and attach a debugger to this thing and see if I can discover where I messed up.

Edit: I fixed my pops that were out of order. I use the attached file for debugging (it changes the sleeves of the default model). When the file is not present, the hook doesn't break the game, so the function call is behaving nicely. When I successfully load the file and generate the attach point (using a code that is almost unmodified from the version that can be found here: https://github.com/Kerilk/bayonetta_patch/blob/07cb8a246f7fc2be80bcfaf5ab5cb42da058533f/src/helper_funcs.c#L10-L32) I get a protection fault down the road...
I don't seem to be trashing the stack, so I don't really understand what's going on here. I must be doing something stupid.

[pl0012.zip](https://github.com/SSSiyan/BayoHook/files/10225007/pl0012.zip)
