### PR TITLE
Add 60 FPS cutscenes patch

### DIFF
--- a/src/gamehook.cpp
+++ b/src/gamehook.cpp
@@ -239,6 +239,18 @@ void GameHook::SwapMashToHold (bool enabled) {
 	}
 }
 
+bool GameHook::sixtyFpsCutscenes_toggle = true;
+void GameHook::SixtyFpsCutscenes(bool enabled) {
+	if (enabled) {
+		GameHook::_nop((char*)(0x45B4A7), 2);
+		GameHook::_patch((char*)(0x45B4BA), (char*)"\xEB", 1); // jmp
+	}
+	else {
+		GameHook::_patch((char*)(0x45B4A7), (char*)"\x74\x28", 2); // jz
+		GameHook::_patch((char*)(0x45B4BA), (char*)"\x74", 1); // jz
+	}
+}
+
 
 // detours
 std::unique_ptr<FunctionHook> enemyHPHook;
@@ -2138,6 +2150,8 @@ void GameHook::onConfigLoad(const utils::Config& cfg) {
 	RetainPillowTalkCharge(retainPillowTalkCharge_toggle);
 	swapMashToHold_toggle = cfg.get<bool>("SwapMashToHoldToggle").value_or(false);
 	SwapMashToHold(swapMashToHold_toggle);
+	sixtyFpsCutscenes_toggle = cfg.get<bool>("60FpsCutscenes").value_or(true);
+	SixtyFpsCutscenes(sixtyFpsCutscenes_toggle);
 	//areaJumpPatch_toggle = cfg.get<bool>("AreaJumpPatchToggle").value_or(false);
 	//AreaJumpPatch(areaJumpPatch_toggle);
 
@@ -2207,6 +2221,7 @@ void GameHook::onConfigSave(utils::Config& cfg) {
 	cfg.set<bool>("WeaponSwapOffsetToggle", weaponSwapOffset_toggle);
 	cfg.set<bool>("RetainPillowTalkChargeToggle", retainPillowTalkCharge_toggle);
 	cfg.set<bool>("SwapMashToHoldToggle", swapMashToHold_toggle);
+	cfg.set<bool>("60FpsCutscenes", sixtyFpsCutscenes_toggle);
 
 	//cfg.set<bool>("AreaJumpPatchToggle", areaJumpPatch_toggle);
 	// detours

--- a/src/gamehook.hpp
+++ b/src/gamehook.hpp
@@ -35,6 +35,7 @@ public:
 	static bool weaponSwapOffset_toggle;
 	static bool retainPillowTalkCharge_toggle;
 	static bool swapMashToHold_toggle;
+	static bool sixtyFpsCutscenes_toggle;
 	// patch functions
 	static void TakeNoDamage(bool enabled);
 	static void DisableKilling(bool enabled);
@@ -60,6 +61,7 @@ public:
 	static void WeaponSwapOffset(bool enabled);
 	static void RetainPillowTalkCharge(bool enabled);
 	static void SwapMashToHold(bool enabled);
+	static void SixtyFpsCutscenes(bool enabled);
 
 	static void WeaponSwapCaller(void);
 	static void SaveStates_SaveState();

--- a/src/gameimgui.cpp
+++ b/src/gameimgui.cpp
@@ -372,6 +372,11 @@ void GameHook::GameImGui(void) {
             ImGui::Checkbox("Skip Angel Attack", &GameHook::loadReplace_toggle);
             help_marker("Load Mission Select instead of Angel Attack");
 
+            ImGui::SameLine(sameLineWidth);
+            if (ImGui::Checkbox("60 FPS Cutscenes", &GameHook::sixtyFpsCutscenes_toggle)) {
+                GameHook::SixtyFpsCutscenes(GameHook::sixtyFpsCutscenes_toggle);
+            }
+
             ImGui::Separator();
 
             ImGui::Checkbox("Force Input Type", &GameHook::inputIcons_toggle);


### PR DESCRIPTION
Adds a patch that makes cutscenes play at 60 FPS, togglable under the "System" tab and enabled by default. (wasn't sure where else to put it.)

Disabling the patch during a cutscene is not going to have any effect till it finishes playing. I hope that's fine.

Had to name the variables and functions "sixty FPS" since you can't start them with numbers.