### PR TITLE
Add "Disable FPS Limiter" patch

### DIFF
--- a/src/gamehook.cpp
+++ b/src/gamehook.cpp
@@ -251,6 +251,20 @@ void GameHook::SixtyFpsCutscenes(bool enabled) {
 	}
 }
 
+bool GameHook::disableFpsLimiter_toggle = false;
+void GameHook::DisableFpsLimiter(bool enabled) {
+	if (enabled) {
+		GameHook::_patch((char*)(0xC54340), (char*)"\xC3", 1); // retn 
+		GameHook::_patch((char*)(0xC54430), (char*)"\xC3", 1); // retn 
+		GameHook::_patch((char*)(0x49E25D), (char*)"\x90\xE9", 2); // jmp
+	}
+	else {
+		GameHook::_patch((char*)(0xC54340), (char*)"\xF3", 1); // movss
+		GameHook::_patch((char*)(0xC54430), (char*)"\xF3", 1); // movss
+		GameHook::_patch((char*)(0x49E25D), (char*)"\x0F\x84", 2); // jz
+	}
+}
+
 bool GameHook::jeanneBayoWT_toggle = true;
 void GameHook::JeanneBayoWT(bool enabled) {
 	if (enabled) {
@@ -2248,6 +2262,8 @@ void GameHook::onConfigLoad(const utils::Config& cfg) {
 	SwapMashToHold(swapMashToHold_toggle);
 	sixtyFpsCutscenes_toggle = cfg.get<bool>("60FpsCutscenes").value_or(false);
 	SixtyFpsCutscenes(sixtyFpsCutscenes_toggle);
+	disableFpsLimiter_toggle = cfg.get<bool>("DisableFpsLimiter").value_or(false);
+	DisableFpsLimiter(disableFpsLimiter_toggle);
 	jeanneBayoWT_toggle = cfg.get<bool>("JeanneBayoWTToggle").value_or(false);
 	JeanneBayoWT(jeanneBayoWT_toggle);
 	infDivekick_toggle = cfg.get<bool>("InfDivekickToggle").value_or(false);
@@ -2331,6 +2347,7 @@ void GameHook::onConfigSave(utils::Config& cfg) {
 	cfg.set<bool>("RetainPillowTalkChargeToggle", retainPillowTalkCharge_toggle);
 	cfg.set<bool>("SwapMashToHoldToggle", swapMashToHold_toggle);
 	cfg.set<bool>("60FpsCutscenes", sixtyFpsCutscenes_toggle);
+	cfg.set<bool>("DisableFpsLimiter", disableFpsLimiter_toggle);
 	cfg.set<bool>("JeanneBayoWTToggle", jeanneBayoWT_toggle);
 	cfg.set<bool>("InfDivekickToggle", infDivekick_toggle);
 	cfg.set<bool>("ParryOffsetToggle", parryOffset_toggle);

--- a/src/gamehook.hpp
+++ b/src/gamehook.hpp
@@ -38,6 +38,7 @@ public:
 	static bool retainPillowTalkCharge_toggle;
 	static bool swapMashToHold_toggle;
 	static bool sixtyFpsCutscenes_toggle;
+	static bool disableFpsLimiter_toggle;
 	static bool jeanneBayoWT_toggle;
 	static bool infDivekick_toggle;
 	static bool parryOffset_toggle;
@@ -68,6 +69,7 @@ public:
 	static void RetainPillowTalkCharge(bool enabled);
 	static void SwapMashToHold(bool enabled);
 	static void SixtyFpsCutscenes(bool enabled);
+	static void DisableFpsLimiter(bool enabled);
 	static void JeanneBayoWT(bool enabled);
 	static void InfDivekick(bool enabled);
 	static void TauntWithTimeBracelet(bool enabled);

--- a/src/gameimgui.cpp
+++ b/src/gameimgui.cpp
@@ -406,6 +406,11 @@ void GameHook::GameImGui(void) {
                 GameHook::SixtyFpsCutscenes(GameHook::sixtyFpsCutscenes_toggle);
             }
 
+            if (ImGui::Checkbox("Disable FPS Limiter", &GameHook::disableFpsLimiter_toggle)) {
+                GameHook::DisableFpsLimiter(GameHook::disableFpsLimiter_toggle);
+            }
+
+            ImGui::SameLine(sameLineWidth);
             ImGui::Checkbox("Pause When Opening BayoHook", &GameHook::openMenuPause_toggle);
 
             if (ImGui::Checkbox("Remove Vignette", &GameHook::removeVignette_toggle)) {


### PR DESCRIPTION
Adds an option to disable the game's own FPS limiter, which has the side effect of speeding the game up above 60 FPS, but give the opportunity to use external frame limiters such as Special K or NVIDIA Control Panel settings.

Bayonetta's frame limiter uses a 32-bit float to store the elapsed time since game boot, which quickly loses precision as you play the game for several minutes and introduce stutters.

Should close https://github.com/SSSiyan/BayoHook/issues/16 